### PR TITLE
Fix boolean

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "FlowYouTube",
     "Description": "Search YouTube.com",
     "Author": "Garulf",
-    "Version": "0.2.0",
+    "Version": "0.2.1",
     "Language": "python",
     "Website": "https://github.com/Garulf/FlowYouTube",
     "IcoPath": "./icon.png",

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from distutils.util import strtobool
 from flox import Flox, utils, ICON_BROWSER
 
 from youtube_search import YoutubeSearch
@@ -38,7 +37,7 @@ class FlowYouTube(Flox):
     def result(self, item, executor):
         icon = self.icon
         url = f'{BASE_URL}{item["url_suffix"]}'
-        download_thumbs = strtobool(self.settings.get('download_thumbs', True))
+        download_thumbs = self.settings.get('download_thumbs', True)
         if download_thumbs:
             icon = utils.get_icon(
                 get_thumbnail(item['id']), 


### PR DESCRIPTION
Remove `strtobool`  module as a non-empty string is considered `True` anyway and subsequent changes use proper Boolean values.