### PR TITLE
Feature: Context menu copy to clipboard and ctrl+c shortcut

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "FlowYouTube",
   "Description": "Search YouTube.com",
   "Author": "Garulf",
-  "Version": "2.0.0",
+  "Version": "2.1.0",
   "Language": "python",
   "Website": "https://github.com/Garulf/FlowYouTube",
   "IcoPath": "./icon.png",

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from subprocess import Popen
 import json
-from flox import Flox, utils, ICON_BROWSER
+from flox import Flox, utils, clipboard, ICON_BROWSER, ICON_COPY
 
 from youtube_search import YoutubeSearch
 
@@ -94,9 +94,19 @@ class FlowYouTube(Flox):
                 method=self.open_in_program,
                 parameters=[program_path, args]
             )
+        self.add_item(
+            title='Copy to clipboard',
+            subtitle=url,
+            icon=ICON_COPY,
+            method=self.copy_to_clipboard,
+            parameters=[url]
+        )
 
     def open_in_program(self, program_path, args):
         proc = Popen([program_path, args])
+
+    def copy_to_clipboard(self, url):
+        clipboard.put(url)
 
 
 if __name__ == "__main__":

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -69,6 +69,7 @@ class FlowYouTube(Flox):
             title=item['title'],
             subtitle=f'{item["publish_time"]} - {item["channel"]} (Length: {item["duration"]})',
             icon=icon,
+            CopyText=url,
             method=self.browser_open,
             parameters=[url],
             context=[url]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flox-lib==0.18.1
+flox-lib==0.19.2
 git+https://github.com/Garulf/youtube_search@feat-custom-region-language
 requests[use_chardet_on_py3]==2.27.1


### PR DESCRIPTION
Adds the option to copy the video URL in the context menu and enables Flow's <kbd>ctrl</kbd>+<kbd>C</kbd> shortcut for videos.

Feature request: https://github.com/Garulf/FlowYouTube/issues/18